### PR TITLE
Add listKey argument to DoctrineListRepresentationFactory and DoctrineNestedListRepresentationFactory

### DIFF
--- a/ListRepresentation/DoctrineListRepresentationFactory.php
+++ b/ListRepresentation/DoctrineListRepresentationFactory.php
@@ -56,10 +56,13 @@ class DoctrineListRepresentationFactory implements DoctrineListRepresentationFac
         array $filters = [],
         array $parameters = [],
         array $includedFields = [],
-        array $groupByFields = []
+        array $groupByFields = [],
+        string $listKey = null
     ): PaginatedRepresentation {
+        $listKey = $listKey ?? $resourceKey;
+
         /** @var DoctrineFieldDescriptor[] $fieldDescriptors */
-        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($resourceKey);
+        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($listKey);
 
         $listBuilder = $this->listBuilderFactory->create($fieldDescriptors['id']->getEntityName());
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);

--- a/ListRepresentation/DoctrineListRepresentationFactoryInterface.php
+++ b/ListRepresentation/DoctrineListRepresentationFactoryInterface.php
@@ -19,6 +19,7 @@ interface DoctrineListRepresentationFactoryInterface
         array $filters = [],
         array $parameters = [],
         array $includedFields = [],
-        array $groupByFields = []
+        array $groupByFields = [],
+        string $listKey = null
     ): PaginatedRepresentation;
 }

--- a/ListRepresentation/DoctrineNestedListRepresentationFactory.php
+++ b/ListRepresentation/DoctrineNestedListRepresentationFactory.php
@@ -61,10 +61,13 @@ class DoctrineNestedListRepresentationFactory implements DoctrineNestedListRepre
         $parentId = null,
         array $expandedIds = [],
         array $includedFields = [],
-        array $groupByFields = []
+        array $groupByFields = [],
+        string $listKey = null
     ): CollectionRepresentation {
+        $listKey = $listKey ?? $resourceKey;
+
         /** @var DoctrineFieldDescriptor[] $fieldDescriptors */
-        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($resourceKey);
+        $fieldDescriptors = $this->fieldDescriptorFactory->getFieldDescriptors($listKey);
         $listBuilder = $this->listBuilderFactory->create($fieldDescriptors['id']->getEntityName());
         $this->restHelper->initializeListBuilder($listBuilder, $fieldDescriptors);
 

--- a/ListRepresentation/DoctrineNestedListRepresentationFactoryInterface.php
+++ b/ListRepresentation/DoctrineNestedListRepresentationFactoryInterface.php
@@ -23,6 +23,7 @@ interface DoctrineNestedListRepresentationFactoryInterface
         $parentId = null,
         array $expandedIds = [],
         array $includedFields = [],
-        array $groupByFields = []
+        array $groupByFields = [],
+        string $listKey = null
     ): CollectionRepresentation;
 }


### PR DESCRIPTION
Currently those classes only work properly, if the `LIST_KEY` and the `RESOURCE_KEY` are equal. If this is not the case, you would have to do something like the following, to make it work:

```php
public function cgetAction(Request $request): Response
{
    $listRepresentation = $this->doctrineListRepresentationFactory->createDoctrineListRepresentation(
        self::LIST_KEY, // Note that this argument is named $resourceKey
    );

    $listRepresentation = new PaginatedRepresentation(
        $listRepresentation->getData(),
        self::RESOURCE_KEY,
        $listRepresentation->getPage(),
        $listRepresentation->getLimit(),
        $listRepresentation->getTotal(),
    );

    return $this->handleView(
        $this->view($listRepresentation)
    );
}
```

With this pull request, the code can be simplified to the following:

```php
public function cgetAction(Request $request): Response
{
    $listRepresentation = $this->doctrineListRepresentationFactory->createDoctrineListRepresentation(
        self::RESOURCE_KEY,
        [],
        [],
        [],
        self::LIST_KEY,
    );

    return $this->handleView(
        $this->view($listRepresentation)
    );
}
```